### PR TITLE
Add rust demangle script

### DIFF
--- a/rust_demangler.py
+++ b/rust_demangler.py
@@ -30,11 +30,9 @@ for f in fns:
     signature = signature.replace("$u20$", " ")
     signature = signature.replace("$C$", ",")
     signature = signature.replace(".", ":")
+    signature = signature.replace(" ", "_")
 
-    try:
-        f.setName(signature, SourceType.ANALYSIS)
-    except:
-        pass
+    f.setName(signature, SourceType.ANALYSIS)
 
 # Get symbols
 st = currentProgram.getSymbolTable();

--- a/rust_demangler.py
+++ b/rust_demangler.py
@@ -1,0 +1,37 @@
+# Demangle swift function names
+# A script can be easily created in the Script Manager window
+# Make sure https://github.com/luser/rustfilt is installed on your system
+
+#@author Thomas Roth
+#@category Ghidra Ninja.Rust
+#@keybinding 
+#@menupath 
+#@toolbar 
+
+from subprocess import Popen, PIPE
+
+from ghidra.program.model.symbol import SourceType
+from ghidra.program.model.listing import CodeUnit
+
+functionManager = currentProgram.getFunctionManager()
+
+# Get functions in ascending order
+fns = functionManager.getFunctions(True)
+for f in fns:
+    f_name = f.getName()
+    # Is it a mangled name?
+    if not (f_name.startswith("_ZN") or f_name.startswith("_R")):
+        continue
+
+    previous_comment = f.getComment()
+    if not previous_comment:
+        previous_comment = ""
+
+    rustfilt = Popen(['rustfilt'], stdin=PIPE, stdout=PIPE)
+    signature = rustfilt.communicate(input=f_name)[0]
+
+    # Replace characters we can't have in our name
+    signature = signature.split("(")[0]
+    signature = signature.replace(" ", "_")
+
+    f.setName(signature, SourceType.ANALYSIS)


### PR DESCRIPTION
Hi, thanks for this very nice set of scripts.

As Ghidra is unable to demangle Rust symbols, this script utilizes the [rustfilt](https://github.com/luser/rustfilt) crate to demangle Rust symbols found in the binary.

Currently the script just assumes that the user has installed the `rustfilt` crate on the system but do let me know if you want me to add any error messages.